### PR TITLE
Update data_conversion docker to use the latest version of aggregation

### DIFF
--- a/data_conversion/Dockerfile
+++ b/data_conversion/Dockerfile
@@ -6,6 +6,6 @@ WORKDIR /tprn_data
 
 RUN pip install --upgrade pip
 RUN pip install -U ujson
-RUN pip install -U git+git://github.com/zooniverse/aggregation-for-caesar.git@seperate-shortcut-tasks
+RUN pip install -U panoptes_aggregation
 
 ADD ./ /tprn_manifest


### PR DESCRIPTION
Fixes #4 The shortcut task has been merged into the latest release of panoptes_aggregation, a specific branch no longer needs to be specified.

Note: the branch this is currently pointing to no longer exists.